### PR TITLE
Fixing bug when loading weights produce by cuda

### DIFF
--- a/dqn_agent.py
+++ b/dqn_agent.py
@@ -31,6 +31,7 @@ engine = TetrisEngine(width, height)
 
 # if gpu is to be used
 use_cuda = torch.cuda.is_available()
+if use_cuda:print("....Using Gpu...")
 FloatTensor = torch.cuda.FloatTensor if use_cuda else torch.FloatTensor
 LongTensor = torch.cuda.LongTensor if use_cuda else torch.LongTensor
 ByteTensor = torch.cuda.ByteTensor if use_cuda else torch.ByteTensor
@@ -302,7 +303,7 @@ if __name__ == '__main__':
             last_state = state
             state, reward, done = engine.step(action[0,0])
             state = FloatTensor(state[None,None,:,:])
-
+            
             # Accumulate reward
             score += int(reward)
 

--- a/run_model.py
+++ b/run_model.py
@@ -7,6 +7,7 @@ from dqn_agent import DQN, ReplayMemory, Transition
 from torch.autograd import Variable
 
 use_cuda = torch.cuda.is_available()
+
 FloatTensor = torch.cuda.FloatTensor if use_cuda else torch.FloatTensor
 LongTensor = torch.cuda.LongTensor if use_cuda else torch.LongTensor
 
@@ -15,7 +16,8 @@ engine = TetrisEngine(width, height)
 
 def load_model(filename):
     model = DQN()
-
+    if use_cuda:
+        model.cuda()
     checkpoint = torch.load(filename)
     model.load_state_dict(checkpoint['state_dict'])
 


### PR DESCRIPTION
Minor fix. The bug was when loading a model that was created on cuda into a model running also in cuda, was not being called the .cuda(). Causing this error:

```bash 
Input type (CUDAFloatTensor) and weight type (CPUFloatTensor) should be the same
```` 